### PR TITLE
Bugfix: Escape spaces in directory path.

### DIFF
--- a/src/ScriptHandler.php
+++ b/src/ScriptHandler.php
@@ -20,6 +20,9 @@ class ScriptHandler
         $filesystem = $filesystem ?: new Filesystem;
 
         foreach ($symlinks as $sourceRelativePath => $targetRelativePath) {
+            // Remove trailing slash that can cause the target to be deleted by ln.
+            $targetRelativePath = rtrim($targetRelativePath, '/');
+
             $sourceAbsolutePath = sprintf('%s/%s', $rootPath, $sourceRelativePath);
             $targetAbsolutePath = sprintf('%s/%s', $rootPath, $targetRelativePath);
             if (!file_exists($sourceAbsolutePath)) {
@@ -29,9 +32,6 @@ class ScriptHandler
             if (file_exists($targetAbsolutePath)) {
                 $filesystem->remove($targetAbsolutePath);
             }
-
-            // Remove trailing slash that can cause the target to be deleted by ln.
-            $targetRelativePath = rtrim($targetRelativePath, '/');
 
             $event->getIO()->write(sprintf(
                 '<info>Creating symlink for "%s" into "%s"</info>',

--- a/src/ScriptHandler.php
+++ b/src/ScriptHandler.php
@@ -45,7 +45,7 @@ class ScriptHandler
             }
 
             // Escape spaces in path.
-	        $targetDirname = preg_replace('/(?<!\\))[ ]/', '\\ ', $targetDirname);
+            $targetDirname = preg_replace('/(?<!\\))[ ]/', '\\ ', $targetDirname);
             
             // Build and execute final command.
             $mkdirCmd = 'mkdir -p ' . $targetDirname;

--- a/src/ScriptHandler.php
+++ b/src/ScriptHandler.php
@@ -44,6 +44,9 @@ class ScriptHandler
                 $command = 'cp -r';
             }
 
+            // Escape spaces in path.
+	        $targetDirname = preg_replace('/(?<!\\))[ ]/', '\\ ', $targetDirname);
+            
             // Build and execute final command.
             $mkdirCmd = 'mkdir -p ' . $targetDirname;
             exec($mkdirCmd);

--- a/src/ScriptHandler.php
+++ b/src/ScriptHandler.php
@@ -46,7 +46,7 @@ class ScriptHandler
 
             // Escape spaces in path.
             $targetDirname = preg_replace('/(?<!\\))[ ]/', '\\ ', $targetDirname);
-            
+
             // Build and execute final command.
             $mkdirCmd = 'mkdir -p ' . $targetDirname;
             exec($mkdirCmd);

--- a/src/ScriptHandler.php
+++ b/src/ScriptHandler.php
@@ -30,6 +30,9 @@ class ScriptHandler
                 $filesystem->remove($targetAbsolutePath);
             }
 
+            // Remove trailing slash that can cause the target to be deleted by ln.
+            $targetRelativePath = rtrim($targetRelativePath, '/');
+
             $event->getIO()->write(sprintf(
                 '<info>Creating symlink for "%s" into "%s"</info>',
                 $sourceRelativePath,

--- a/tests/ScriptHandlerTest.php
+++ b/tests/ScriptHandlerTest.php
@@ -54,4 +54,22 @@ class ScriptHandlerTest extends TestCase
         ]);
         ScriptHandler::createSymlinks($this->event, $this->filesystem);
     }
+
+    /**
+     * As the `ln` command is executed, it first `cd`s into the destination directory. If there is a space
+     * anywhere in the path, the `cd` command fails to run properly and the operation fails.
+     *
+     * @see https://www.phpliveregex.com/p/uaf#tab-preg-replace
+     */
+    function test_escape_spaces_in_target_dir()
+    {
+        $sampledir = '/users/BrianHenryIE/Sites/foo bar/';
+
+        $expected = '/users/BrianHenryIE/Sites/foo\ bar/';
+
+        $actual = preg_replace('/(?<!\\))[ ]/', '\\ ', $sampledir);
+
+        $this->assertSame($expected, $actual);
+    }
+
 }

--- a/tests/ScriptHandlerTest.php
+++ b/tests/ScriptHandlerTest.php
@@ -73,7 +73,7 @@ class ScriptHandlerTest extends TestCase
     }
 
     /**
-     * When the destination of the symlink contained a trailing slash, the source would be deleted.
+     * When the location of the new symlink contained a trailing slash, the original data would be deleted.
      *
      * e.g. the config "trunk": "wp-content/plugins/bh-wp-technique-gym/" would delete trunk.
      */

--- a/tests/ScriptHandlerTest.php
+++ b/tests/ScriptHandlerTest.php
@@ -72,4 +72,27 @@ class ScriptHandlerTest extends TestCase
         $this->assertSame($expected, $actual);
     }
 
+    /**
+     * When the destination of the symlink contained a trailing slash, the source would be deleted.
+     *
+     * e.g. the config "trunk": "wp-content/plugins/bh-wp-technique-gym/" would delete trunk.
+     */
+    function test_input_sanitization()
+    {
+        $this->io
+            ->expects($this->exactly(1))
+            ->method('write')
+            ->withConsecutive(
+                ['<info>Creating symlink for "foo" into "bar"</info>'],
+                ['<info>Creating symlink for "foo2" into "bar"</info>']
+            );
+
+        $this->package->setExtra([
+            'symlinks' => [
+                'foo' => 'bar/',
+                'foo2' => 'bar',
+            ],
+        ]);
+        ScriptHandler::createSymlinks($this->event, $this->filesystem);
+    }
 }


### PR DESCRIPTION
The `cd` command was reaching the wrong directory when the directory path contained a space.